### PR TITLE
Fixed the area of many prefabs + ladders

### DIFF
--- a/Locations/LocationPrefab/WOD_BanditCamp_01.txt
+++ b/Locations/LocationPrefab/WOD_BanditCamp_01.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>2</height>
-	<width>2</width>
+	<height>5</height>
+	<width>6</width>
 	<object>
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>41130</name>
-		<posX>3.29</posX>
+		<posX>18.06</posX>
 		<posY>0.598</posY>
-		<posZ>10.41</posZ>
+		<posZ>16.78</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>41106</name>
-		<posX>8.28</posX>
+		<posX>23.05</posX>
 		<posY>0.36</posY>
-		<posZ>4.8</posZ>
+		<posZ>11.17</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>41100</name>
-		<posX>3.74</posX>
+		<posX>18.51</posX>
 		<posY>0.399</posY>
-		<posZ>10.07</posZ>
+		<posZ>16.44</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -50,24 +50,20 @@
 		<type>1</type>
 		<objectID>3</objectID>
 		<name>210.1</name>
-		<posX>6.42</posX>
+		<posX>21.19</posX>
 		<posY>0.437</posY>
-		<posZ>6.1</posZ>
+		<posZ>12.47</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>41106</name>
-		<posX>7.41</posX>
+		<posX>22.18</posX>
 		<posY>0.36</posY>
-		<posZ>7.95</posZ>
+		<posZ>14.32</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -80,9 +76,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>41106</name>
-		<posX>4.46</posX>
+		<posX>19.23</posX>
 		<posY>0.36</posY>
-		<posZ>5.82</posZ>
+		<posZ>12.19</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -95,54 +91,42 @@
 		<type>1</type>
 		<objectID>6</objectID>
 		<name>216.1</name>
-		<posX>3.63</posX>
+		<posX>18.4</posX>
 		<posY>0.883</posY>
-		<posZ>10.617</posZ>
+		<posZ>16.987</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>7</objectID>
 		<name>216.0</name>
-		<posX>2.929</posX>
+		<posX>17.699</posX>
 		<posY>0.99</posY>
-		<posZ>10.162</posZ>
+		<posZ>16.532</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>10</objectID>
 		<name>205.3</name>
-		<posX>4.49</posX>
+		<posX>19.26</posX>
 		<posY>0.242</posY>
-		<posZ>4.506</posZ>
+		<posZ>10.876</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>11</objectID>
 		<name>60610</name>
-		<posX>-2.307</posX>
+		<posX>12.463</posX>
 		<posY>3.111</posY>
-		<posZ>2.621</posZ>
+		<posZ>8.991</posZ>
 		<scaleX>2.792936</scaleX>
 		<scaleY>3.008</scaleY>
 		<scaleZ>2.049</scaleZ>
@@ -155,9 +139,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60610</name>
-		<posX>-2.282317</posX>
+		<posX>12.48768</posX>
 		<posY>3.127112</posY>
-		<posZ>11.92772</posZ>
+		<posZ>18.29772</posZ>
 		<scaleX>2.792936</scaleX>
 		<scaleY>3.008</scaleY>
 		<scaleZ>2.049</scaleZ>
@@ -170,9 +154,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60610</name>
-		<posX>0.02316204</posX>
+		<posX>14.79316</posX>
 		<posY>2.611368</posY>
-		<posZ>14.33034</posZ>
+		<posZ>20.70034</posZ>
 		<scaleX>2.792936</scaleX>
 		<scaleY>3.008</scaleY>
 		<scaleZ>2.049</scaleZ>
@@ -185,9 +169,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60610</name>
-		<posX>9.22</posX>
+		<posX>23.99</posX>
 		<posY>1.47</posY>
-		<posZ>16.76</posZ>
+		<posZ>23.13</posZ>
 		<scaleX>2.792936</scaleX>
 		<scaleY>3.008</scaleY>
 		<scaleZ>2.049</scaleZ>
@@ -200,9 +184,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60610</name>
-		<posX>16.79</posX>
+		<posX>31.56</posX>
 		<posY>0.74</posY>
-		<posZ>0.47</posZ>
+		<posZ>6.84</posZ>
 		<scaleX>2.792936</scaleX>
 		<scaleY>3.008</scaleY>
 		<scaleZ>2.049</scaleZ>
@@ -215,9 +199,9 @@
 		<type>0</type>
 		<objectID>16</objectID>
 		<name>41818</name>
-		<posX>1.99</posX>
+		<posX>16.76</posX>
 		<posY>0.37</posY>
-		<posZ>4.96</posZ>
+		<posZ>11.33</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -230,9 +214,9 @@
 		<type>0</type>
 		<objectID>17</objectID>
 		<name>41832</name>
-		<posX>2.34</posX>
+		<posX>17.11</posX>
 		<posY>0.71</posY>
-		<posZ>3.9</posZ>
+		<posZ>10.27</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -245,69 +229,53 @@
 		<type>1</type>
 		<objectID>18</objectID>
 		<name>100.0</name>
-		<posX>6.06</posX>
+		<posX>20.83</posX>
 		<posY>0</posY>
-		<posZ>3.818</posZ>
+		<posZ>10.188</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>19</objectID>
 		<name>100.1</name>
-		<posX>4.74</posX>
+		<posX>19.51</posX>
 		<posY>0</posY>
-		<posZ>2.45</posZ>
+		<posZ>8.82</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>8</objectID>
 		<name>201.00</name>
-		<posX>9.41</posX>
+		<posX>24.18</posX>
 		<posY>0</posY>
-		<posZ>11.47</posZ>
+		<posZ>17.84</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>9</objectID>
 		<name>201.01</name>
-		<posX>10.19</posX>
+		<posX>24.96</posX>
 		<posY>0</posY>
-		<posZ>9.02</posZ>
+		<posZ>15.39</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>20</objectID>
 		<name>60718</name>
-		<posX>-5.776</posX>
+		<posX>8.994</posX>
 		<posY>-3.6</posY>
-		<posZ>15.414</posZ>
+		<posZ>21.784</posZ>
 		<scaleX>10.50822</scaleX>
 		<scaleY>17.07028</scaleY>
 		<scaleZ>12.4957</scaleZ>
@@ -320,9 +288,9 @@
 		<type>0</type>
 		<objectID>21</objectID>
 		<name>60718</name>
-		<posX>-9.929272</posX>
+		<posX>4.840729</posX>
 		<posY>-3.6</posY>
-		<posZ>8.510494</posZ>
+		<posZ>14.88049</posZ>
 		<scaleX>10.50822</scaleX>
 		<scaleY>17.07028</scaleY>
 		<scaleZ>12.4957</scaleZ>
@@ -335,9 +303,9 @@
 		<type>0</type>
 		<objectID>22</objectID>
 		<name>60718</name>
-		<posX>8.82</posX>
+		<posX>23.59</posX>
 		<posY>-3.6</posY>
-		<posZ>22.37</posZ>
+		<posZ>28.74</posZ>
 		<scaleX>10.50822</scaleX>
 		<scaleY>17.07028</scaleY>
 		<scaleZ>14.94486</scaleZ>
@@ -350,9 +318,9 @@
 		<type>0</type>
 		<objectID>23</objectID>
 		<name>60711</name>
-		<posX>15.2</posX>
+		<posX>29.97</posX>
 		<posY>-5.926</posY>
-		<posZ>0.444</posZ>
+		<posZ>6.814</posZ>
 		<scaleX>18.899</scaleX>
 		<scaleY>15.814</scaleY>
 		<scaleZ>15.82416</scaleZ>
@@ -365,9 +333,9 @@
 		<type>0</type>
 		<objectID>24</objectID>
 		<name>60711</name>
-		<posX>-1.28</posX>
+		<posX>13.49</posX>
 		<posY>-7.09</posY>
-		<posZ>1.91</posZ>
+		<posZ>8.28</posZ>
 		<scaleX>18.899</scaleX>
 		<scaleY>18.78703</scaleY>
 		<scaleZ>17.29581</scaleZ>
@@ -380,9 +348,9 @@
 		<type>0</type>
 		<objectID>25</objectID>
 		<name>60711</name>
-		<posX>10.45</posX>
+		<posX>25.22</posX>
 		<posY>-7.09</posY>
-		<posZ>16.1</posZ>
+		<posZ>22.47</posZ>
 		<scaleX>18.899</scaleX>
 		<scaleY>18.78703</scaleY>
 		<scaleZ>17.29581</scaleZ>
@@ -395,75 +363,55 @@
 		<type>1</type>
 		<objectID>26</objectID>
 		<name>479.0</name>
-		<posX>7.43</posX>
+		<posX>22.2</posX>
 		<posY>0.99</posY>
-		<posZ>5.13</posZ>
+		<posZ>11.5</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>27</objectID>
 		<name>479.0</name>
-		<posX>6.88</posX>
+		<posX>21.65</posX>
 		<posY>0.99</posY>
-		<posZ>7.225</posZ>
+		<posZ>13.595</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>28</objectID>
 		<name>479.0</name>
-		<posX>5.19</posX>
+		<posX>19.96</posX>
 		<posY>0.99</posY>
-		<posZ>6.01</posZ>
+		<posZ>12.38</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>29</objectID>
 		<name>479.0</name>
-		<posX>5.19</posX>
+		<posX>19.96</posX>
 		<posY>0.99</posY>
-		<posZ>11.11</posZ>
+		<posZ>17.48</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>30</objectID>
 		<name>479.0</name>
-		<posX>11.66</posX>
+		<posX>26.43</posX>
 		<posY>0.99</posY>
-		<posZ>11.53</posZ>
+		<posZ>17.9</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_BanditCamp_02.txt
+++ b/Locations/LocationPrefab/WOD_BanditCamp_02.txt
@@ -1,28 +1,24 @@
 <locationPrefab>
-	<height>4</height>
-	<width>4</width>
+	<height>7</height>
+	<width>6</width>
 	<object>
 		<type>1</type>
 		<objectID>0</objectID>
 		<name>210.1</name>
-		<posX>9.2</posX>
+		<posX>18.1</posX>
 		<posY>0</posY>
-		<posZ>10.7</posZ>
+		<posZ>23.3</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>41734</name>
-		<posX>8.44</posX>
+		<posX>17.34</posX>
 		<posY>0</posY>
-		<posZ>7.05</posZ>
+		<posZ>19.65</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -35,9 +31,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>41734</name>
-		<posX>11.33</posX>
+		<posX>20.23</posX>
 		<posY>0</posY>
-		<posZ>14.73</posZ>
+		<posZ>27.33</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -50,9 +46,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>41734</name>
-		<posX>5.66</posX>
+		<posX>14.56</posX>
 		<posY>0</posY>
-		<posZ>13.21</posZ>
+		<posZ>25.81</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -65,9 +61,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>41606</name>
-		<posX>16.33105</posX>
+		<posX>25.23105</posX>
 		<posY>0.48</posY>
-		<posZ>8.249161</posZ>
+		<posZ>20.84916</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -80,9 +76,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>41606</name>
-		<posX>17.06872</posX>
+		<posX>25.96872</posX>
 		<posY>0.48</posY>
-		<posZ>15.57189</posZ>
+		<posZ>28.17189</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -95,24 +91,20 @@
 		<type>1</type>
 		<objectID>9</objectID>
 		<name>212.11</name>
-		<posX>17.98</posX>
+		<posX>26.88</posX>
 		<posY>0</posY>
-		<posZ>9.87</posZ>
+		<posZ>22.47</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>10</objectID>
 		<name>41825</name>
-		<posX>14.43</posX>
+		<posX>23.33</posX>
 		<posY>0.15</posY>
-		<posZ>15.94</posZ>
+		<posZ>28.54</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -125,9 +117,9 @@
 		<type>0</type>
 		<objectID>11</objectID>
 		<name>41825</name>
-		<posX>14.47</posX>
+		<posX>23.37</posX>
 		<posY>0.15</posY>
-		<posZ>7.11</posZ>
+		<posZ>19.71</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -140,9 +132,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>41001</name>
-		<posX>16.26</posX>
+		<posX>25.16</posX>
 		<posY>-0.26</posY>
-		<posZ>8.4</posZ>
+		<posZ>21</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -155,9 +147,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>41001</name>
-		<posX>17.15111</posX>
+		<posX>26.05111</posX>
 		<posY>-0.26</posY>
-		<posZ>15.62119</posZ>
+		<posZ>28.22119</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -170,9 +162,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60610</name>
-		<posX>-0.8</posX>
+		<posX>8.1</posX>
 		<posY>-4.3</posY>
-		<posZ>-0.2</posZ>
+		<posZ>12.4</posZ>
 		<scaleX>3.842</scaleX>
 		<scaleY>3.905</scaleY>
 		<scaleZ>3.552</scaleZ>
@@ -185,9 +177,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60610</name>
-		<posX>26.1</posX>
+		<posX>35</posX>
 		<posY>-2.4</posY>
-		<posZ>-3.15</posZ>
+		<posZ>9.449999</posZ>
 		<scaleX>3.842</scaleX>
 		<scaleY>3.905</scaleY>
 		<scaleZ>3.552</scaleZ>
@@ -200,9 +192,9 @@
 		<type>0</type>
 		<objectID>16</objectID>
 		<name>60610</name>
-		<posX>14.3</posX>
+		<posX>23.2</posX>
 		<posY>0.66</posY>
-		<posZ>28.93</posZ>
+		<posZ>41.53</posZ>
 		<scaleX>3.842</scaleX>
 		<scaleY>3.905</scaleY>
 		<scaleZ>3.552</scaleZ>
@@ -215,120 +207,88 @@
 		<type>1</type>
 		<objectID>31</objectID>
 		<name>478.1</name>
-		<posX>9.27</posX>
+		<posX>18.17</posX>
 		<posY>1.06</posY>
-		<posZ>7.28</posZ>
+		<posZ>19.88</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>32</objectID>
 		<name>478.1</name>
-		<posX>10.16</posX>
+		<posX>19.06</posX>
 		<posY>1.06</posY>
-		<posZ>14.84</posZ>
+		<posZ>27.44</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>33</objectID>
 		<name>478.1</name>
-		<posX>6.52</posX>
+		<posX>15.42</posX>
 		<posY>1.06</posY>
-		<posZ>13.19</posZ>
+		<posZ>25.79</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>34</objectID>
 		<name>478.1</name>
-		<posX>23.61</posX>
+		<posX>32.51</posX>
 		<posY>1.06</posY>
-		<posZ>23.35</posZ>
+		<posZ>35.95</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>35</objectID>
 		<name>478.1</name>
-		<posX>20.01</posX>
+		<posX>28.91</posX>
 		<posY>1.06</posY>
-		<posZ>3.27</posZ>
+		<posZ>15.87</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>36</objectID>
 		<name>216.32</name>
-		<posX>13.61</posX>
+		<posX>22.51</posX>
 		<posY>0.35</posY>
-		<posZ>9.68</posZ>
+		<posZ>22.28</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>37</objectID>
 		<name>216.32</name>
-		<posX>15.19</posX>
+		<posX>24.09</posX>
 		<posY>0.35</posY>
-		<posZ>17.43</posZ>
+		<posZ>30.03</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
 		<objectID>38</objectID>
 		<name>216.32</name>
-		<posX>6.51</posX>
+		<posX>15.41</posX>
 		<posY>0.35</posY>
-		<posZ>18.09</posZ>
+		<posZ>30.69</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_BanditFort_01.txt
+++ b/Locations/LocationPrefab/WOD_BanditFort_01.txt
@@ -521,10 +521,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -536,10 +532,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -551,10 +543,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -566,10 +554,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -581,10 +565,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -596,10 +576,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -611,10 +587,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -626,10 +598,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -641,10 +609,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -656,10 +620,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -671,10 +631,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -686,10 +642,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -701,9 +653,27 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>47</objectID>
+		<name>199.21</name>
+		<posX>13.379</posX>
+		<posY>0.68</posY>
+		<posZ>16.582</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>48</objectID>
+		<name>199.22</name>
+		<posX>15.898</posX>
+		<posY>13.79</posY>
+		<posZ>18.362</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_BanditFort_02.txt
+++ b/Locations/LocationPrefab/WOD_BanditFort_02.txt
@@ -236,10 +236,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -251,10 +247,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -266,10 +258,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -281,10 +269,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -296,10 +280,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -311,10 +291,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -326,10 +302,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -341,10 +313,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
@@ -581,10 +549,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -596,10 +560,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -611,10 +571,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -626,10 +582,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -641,10 +593,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -656,10 +604,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -671,10 +615,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -686,10 +626,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -701,10 +637,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -716,10 +648,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -731,10 +659,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -746,10 +670,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -761,10 +681,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -776,10 +692,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -791,10 +703,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -806,10 +714,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -821,10 +725,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -836,10 +736,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -851,10 +747,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -866,10 +758,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -881,10 +769,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -896,10 +780,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -911,10 +791,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -926,10 +802,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -941,10 +813,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -956,10 +824,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -971,10 +835,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -986,9 +846,94 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>67</objectID>
+		<name>199.21</name>
+		<posX>36.66</posX>
+		<posY>0.711</posY>
+		<posZ>26.88</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>68</objectID>
+		<name>199.22</name>
+		<posX>36.657</posX>
+		<posY>13.698</posY>
+		<posZ>24.323</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+	</object>
+	<object>
+		<type>0</type>
+		<objectID>69</objectID>
+		<name>41409</name>
+		<posX>19.196</posX>
+		<posY>1.131</posY>
+		<posZ>38.507</posZ>
+		<scaleX>0.60046</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+		<rotW>0.2298443</rotW>
 		<rotX>0</rotX>
-		<rotY>0</rotY>
+		<rotY>0.9732274</rotY>
 		<rotZ>0</rotZ>
+	</object>
+	<object>
+		<type>0</type>
+		<objectID>70</objectID>
+		<name>41409</name>
+		<posX>19.196</posX>
+		<posY>4.202</posY>
+		<posZ>38.507</posZ>
+		<scaleX>0.60046</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+		<rotW>0.2298443</rotW>
+		<rotX>0</rotX>
+		<rotY>0.9732274</rotY>
+		<rotZ>0</rotZ>
+	</object>
+	<object>
+		<type>0</type>
+		<objectID>71</objectID>
+		<name>41409</name>
+		<posX>19.196</posX>
+		<posY>7.12</posY>
+		<posZ>38.507</posZ>
+		<scaleX>0.60046</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+		<rotW>0.2298443</rotW>
+		<rotX>0</rotX>
+		<rotY>0.9732274</rotY>
+		<rotZ>0</rotZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>72</objectID>
+		<name>199.21</name>
+		<posX>19.837</posX>
+		<posY>0.711</posY>
+		<posZ>37.349</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>73</objectID>
+		<name>199.22</name>
+		<posX>18.791</posX>
+		<posY>8.93</posY>
+		<posZ>39.226</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_BanditFort_03.txt
+++ b/Locations/LocationPrefab/WOD_BanditFort_03.txt
@@ -356,10 +356,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>0.963657</rotW>
-		<rotX>0</rotX>
-		<rotY>0.2671426</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
@@ -373,7 +369,7 @@
 		<scaleZ>0.5</scaleZ>
 		<rotW>0.9999664</rotW>
 		<rotX>0</rotX>
-		<rotY>-0.008197248</rotY>
+		<rotY>-0.008197249</rotY>
 		<rotZ>0</rotZ>
 	</object>
 	<object>
@@ -1091,10 +1087,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1106,10 +1098,6 @@
 		<scaleX>2</scaleX>
 		<scaleY>2</scaleY>
 		<scaleZ>2</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
@@ -1121,7 +1109,7 @@
 		<scaleX>0.5</scaleX>
 		<scaleY>0.5</scaleY>
 		<scaleZ>0.5</scaleZ>
-		<rotW>0.9944219</rotW>
+		<rotW>0.994422</rotW>
 		<rotX>0</rotX>
 		<rotY>0.1054753</rotY>
 		<rotZ>0</rotZ>
@@ -1421,10 +1409,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1436,10 +1420,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1451,10 +1431,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1466,10 +1442,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1481,10 +1453,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1496,10 +1464,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1511,10 +1475,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1526,10 +1486,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1541,10 +1497,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1556,10 +1508,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1571,10 +1519,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1586,10 +1530,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1601,10 +1541,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1616,10 +1552,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1631,10 +1563,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1646,10 +1574,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1661,10 +1585,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1676,10 +1596,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1691,10 +1607,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1706,10 +1618,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1721,10 +1629,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1736,10 +1640,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
@@ -1811,10 +1711,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1826,10 +1722,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1841,10 +1733,6 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>1</type>
@@ -1856,9 +1744,27 @@
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
-		<rotW>1</rotW>
-		<rotX>0</rotX>
-		<rotY>0</rotY>
-		<rotZ>0</rotZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>108</objectID>
+		<name>199.21</name>
+		<posX>46.239</posX>
+		<posY>0.686</posY>
+		<posZ>18.771</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
+	</object>
+	<object>
+		<type>2</type>
+		<objectID>109</objectID>
+		<name>199.22</name>
+		<posX>47.983</posX>
+		<posY>6.9</posY>
+		<posZ>17.52</posZ>
+		<scaleX>1</scaleX>
+		<scaleY>1</scaleY>
+		<scaleZ>1</scaleZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_00.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_00.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>88</height>
+	<width>88</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>1.112739</posX>
+		<posX>254.1127</posX>
 		<posY>-61.7</posY>
-		<posZ>124.3009</posZ>
+		<posZ>210.1009</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-1.3</posX>
+		<posX>251.7</posX>
 		<posY>-63.4</posY>
-		<posZ>164</posZ>
+		<posZ>249.8</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>191.8</posX>
+		<posX>444.8</posX>
 		<posY>-64</posY>
-		<posZ>129.8292</posZ>
+		<posZ>215.6292</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>-1.3</posX>
+		<posX>251.7</posX>
 		<posY>-63.4</posY>
-		<posZ>354.2</posZ>
+		<posZ>440</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>1.112739</posX>
+		<posX>254.1127</posX>
 		<posY>-63.4</posY>
-		<posZ>296.2</posZ>
+		<posZ>382</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>347</posX>
+		<posX>600</posX>
 		<posY>-205.7</posY>
-		<posZ>229.2</posZ>
+		<posZ>315</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>21810</name>
-		<posX>126</posX>
+		<posX>379</posX>
 		<posY>-48</posY>
-		<posZ>199</posZ>
+		<posZ>284.8</posZ>
 		<scaleX>3.5155</scaleX>
 		<scaleY>3.22575</scaleY>
 		<scaleZ>3.42592</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>129</posX>
+		<posX>382</posX>
 		<posY>-205.7</posY>
-		<posZ>414.2</posZ>
+		<posZ>500</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>-138.7</posX>
+		<posX>114.3</posX>
 		<posY>-205.7</posY>
-		<posZ>298.5</posZ>
+		<posZ>384.3</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>-129</posX>
+		<posX>124</posX>
 		<posY>-205.7</posY>
-		<posZ>-14.8</posZ>
+		<posZ>71</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>7</objectID>
 		<name>60711</name>
-		<posX>262.4</posX>
+		<posX>515.4</posX>
 		<posY>-205.7</posY>
-		<posZ>-50.8</posZ>
+		<posZ>35</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>10</objectID>
 		<name>60711</name>
-		<posX>127</posX>
+		<posX>380</posX>
 		<posY>-205.7</posY>
-		<posZ>-64.8</posZ>
+		<posZ>21</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,24 +185,24 @@
 		<type>0</type>
 		<objectID>11</objectID>
 		<name>60711</name>
-		<posX>-179</posX>
+		<posX>74</posX>
 		<posY>-63.4</posY>
-		<posZ>90.7</posZ>
+		<posZ>176.5</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>561.2479</scaleZ>
 		<rotW>0.1594201</rotW>
 		<rotX>0</rotX>
-		<rotY>0.9872108</rotY>
+		<rotY>0.9872109</rotY>
 		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60715</name>
-		<posX>166.3</posX>
+		<posX>419.3</posX>
 		<posY>-69.5</posY>
-		<posZ>288.7</posZ>
+		<posZ>374.5</posZ>
 		<scaleX>213.9373</scaleX>
 		<scaleY>390.8421</scaleY>
 		<scaleZ>213.9373</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_00r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_00r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>88</height>
+	<width>88</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>1.112739</posX>
+		<posX>277.5</posX>
 		<posY>-61.7</posY>
-		<posZ>124.3009</posZ>
+		<posZ>203.6009</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-1.3</posX>
+		<posX>275.0873</posX>
 		<posY>-63.4</posY>
-		<posZ>164</posZ>
+		<posZ>243.3</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>191.8</posX>
+		<posX>468.1873</posX>
 		<posY>-64</posY>
-		<posZ>129.8292</posZ>
+		<posZ>209.1292</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>-1.3</posX>
+		<posX>275.0873</posX>
 		<posY>-63.4</posY>
-		<posZ>354.2</posZ>
+		<posZ>433.5</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>1.112739</posX>
+		<posX>277.5</posX>
 		<posY>-63.4</posY>
-		<posZ>296.2</posZ>
+		<posZ>375.5</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>347</posX>
+		<posX>623.3873</posX>
 		<posY>-205.7</posY>
-		<posZ>229.2</posZ>
+		<posZ>308.5</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>21810</name>
-		<posX>126</posX>
+		<posX>402.3873</posX>
 		<posY>-48</posY>
-		<posZ>199</posZ>
+		<posZ>278.3</posZ>
 		<scaleX>3.5155</scaleX>
 		<scaleY>3.22575</scaleY>
 		<scaleZ>3.42592</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>129</posX>
+		<posX>405.3873</posX>
 		<posY>-205.7</posY>
-		<posZ>414.2</posZ>
+		<posZ>493.5</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>-138.7</posX>
+		<posX>137.6873</posX>
 		<posY>-205.7</posY>
-		<posZ>298.5</posZ>
+		<posZ>377.8</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>-129</posX>
+		<posX>147.3873</posX>
 		<posY>-205.7</posY>
-		<posZ>-14.8</posZ>
+		<posZ>64.49998</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>7</objectID>
 		<name>60711</name>
-		<posX>262.4</posX>
+		<posX>538.7872</posX>
 		<posY>-205.7</posY>
-		<posZ>-50.8</posZ>
+		<posZ>28.49999</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>10</objectID>
 		<name>60711</name>
-		<posX>127</posX>
+		<posX>403.3873</posX>
 		<posY>-205.7</posY>
-		<posZ>-64.8</posZ>
+		<posZ>14.49998</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,15 +185,15 @@
 		<type>0</type>
 		<objectID>11</objectID>
 		<name>60711</name>
-		<posX>-179</posX>
+		<posX>97.38727</posX>
 		<posY>-63.4</posY>
-		<posZ>90.7</posZ>
+		<posZ>170</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>561.2479</scaleZ>
 		<rotW>0.1594201</rotW>
 		<rotX>0</rotX>
-		<rotY>0.9872108</rotY>
+		<rotY>0.9872109</rotY>
 		<rotZ>0</rotZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_01.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_01.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>104</height>
+	<width>64</width>
 	<object>
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>21811</name>
-		<posX>0</posX>
+		<posX>2.399994</posX>
 		<posY>31.40002</posY>
-		<posZ>0</posZ>
+		<posZ>117.2</posZ>
 		<scaleX>1</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>21812</name>
-		<posX>154</posX>
+		<posX>156.4</posX>
 		<posY>31.40002</posY>
-		<posZ>348.1</posZ>
+		<posZ>465.3</posZ>
 		<scaleX>1.127453</scaleX>
 		<scaleY>0.74476</scaleY>
 		<scaleZ>0.8197708</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>21810</name>
-		<posX>326.5</posX>
+		<posX>328.9</posX>
 		<posY>4.000025</posY>
-		<posZ>152.9</posZ>
+		<posZ>270.1</posZ>
 		<scaleX>1.4611</scaleX>
 		<scaleY>1.5987</scaleY>
 		<scaleZ>1.2148</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>21812</name>
-		<posX>331</posX>
+		<posX>333.4</posX>
 		<posY>7.500025</posY>
-		<posZ>210.1</posZ>
+		<posZ>327.3</posZ>
 		<scaleX>1.127453</scaleX>
 		<scaleY>0.74476</scaleY>
 		<scaleZ>0.8197708</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60715</name>
-		<posX>271.3</posX>
+		<posX>273.7</posX>
 		<posY>2.6627</posY>
-		<posZ>376.94</posZ>
+		<posZ>494.14</posZ>
 		<scaleX>105.2036</scaleX>
 		<scaleY>127.1108</scaleY>
 		<scaleZ>77.49567</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60715</name>
-		<posX>331.94</posX>
+		<posX>334.34</posX>
 		<posY>26.35</posY>
-		<posZ>332.46</posZ>
+		<posZ>449.66</posZ>
 		<scaleX>120.5835</scaleX>
 		<scaleY>130.7435</scaleY>
 		<scaleZ>82.29999</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>21812</name>
-		<posX>404.6</posX>
+		<posX>407</posX>
 		<posY>-57.19997</posY>
-		<posZ>36.8</posZ>
+		<posZ>154</posZ>
 		<scaleX>1.127453</scaleX>
 		<scaleY>1.209565</scaleY>
 		<scaleZ>0.8197708</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>7</objectID>
 		<name>21812</name>
-		<posX>237.7</posX>
+		<posX>240.1</posX>
 		<posY>-57.19997</posY>
-		<posZ>-68.5</posZ>
+		<posZ>48.7</posZ>
 		<scaleX>2.304063</scaleX>
 		<scaleY>2.141902</scaleY>
 		<scaleZ>1.419363</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>21812</name>
-		<posX>89.4</posX>
+		<posX>91.8</posX>
 		<posY>-47.19997</posY>
-		<posZ>-68.5</posZ>
+		<posZ>48.7</posZ>
 		<scaleX>1.127453</scaleX>
 		<scaleY>1.209565</scaleY>
 		<scaleZ>0.8197708</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>21812</name>
-		<posX>14.2</posX>
+		<posX>16.59999</posX>
 		<posY>-12.89997</posY>
-		<posZ>245</posZ>
+		<posZ>362.2</posZ>
 		<scaleX>1.596377</scaleX>
 		<scaleY>1.724492</scaleY>
 		<scaleZ>0.8197708</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>10</objectID>
 		<name>21812</name>
-		<posX>150</posX>
+		<posX>152.4</posX>
 		<posY>44.9</posY>
-		<posZ>183.9</posZ>
+		<posZ>301.1</posZ>
 		<scaleX>1.5972</scaleX>
 		<scaleY>1</scaleY>
 		<scaleZ>1.004572</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>11</objectID>
 		<name>21812</name>
-		<posX>425</posX>
+		<posX>427.4</posX>
 		<posY>-194</posY>
-		<posZ>243</posZ>
+		<posZ>360.2</posZ>
 		<scaleX>2.004535</scaleX>
 		<scaleY>2.141902</scaleY>
 		<scaleZ>1.419363</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>21812</name>
-		<posX>188</posX>
+		<posX>190.4</posX>
 		<posY>-194</posY>
-		<posZ>478</posZ>
+		<posZ>595.2</posZ>
 		<scaleX>2.004535</scaleX>
 		<scaleY>2.141902</scaleY>
 		<scaleZ>1.419363</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>21812</name>
-		<posX>-191</posX>
+		<posX>-188.6</posX>
 		<posY>-55</posY>
-		<posZ>105</posZ>
+		<posZ>222.2</posZ>
 		<scaleX>1.531124</scaleX>
 		<scaleY>2.141902</scaleY>
 		<scaleZ>1.419363</scaleZ>
@@ -215,9 +215,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>21812</name>
-		<posX>-161.2</posX>
+		<posX>-158.8</posX>
 		<posY>-12.9</posY>
-		<posZ>-183</posZ>
+		<posZ>-65.8</posZ>
 		<scaleX>1.531124</scaleX>
 		<scaleY>2.141902</scaleY>
 		<scaleZ>1.419363</scaleZ>
@@ -230,9 +230,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60713</name>
-		<posX>133.2</posX>
+		<posX>135.6</posX>
 		<posY>87.4</posY>
-		<posZ>-23.2</posZ>
+		<posZ>94</posZ>
 		<scaleX>230.9814</scaleX>
 		<scaleY>192.5955</scaleY>
 		<scaleZ>250.2257</scaleZ>
@@ -245,9 +245,9 @@
 		<type>0</type>
 		<objectID>26</objectID>
 		<name>60713</name>
-		<posX>190</posX>
+		<posX>192.4</posX>
 		<posY>42</posY>
-		<posZ>33</posZ>
+		<posZ>150.2</posZ>
 		<scaleX>230.9814</scaleX>
 		<scaleY>192.5955</scaleY>
 		<scaleZ>250.2257</scaleZ>
@@ -260,9 +260,9 @@
 		<type>0</type>
 		<objectID>16</objectID>
 		<name>60715</name>
-		<posX>176.63</posX>
+		<posX>179.03</posX>
 		<posY>-3.4563</posY>
-		<posZ>457.9</posZ>
+		<posZ>575.1</posZ>
 		<scaleX>134.5659</scaleX>
 		<scaleY>155.5815</scaleY>
 		<scaleZ>125.3153</scaleZ>
@@ -275,9 +275,9 @@
 		<type>0</type>
 		<objectID>17</objectID>
 		<name>21812</name>
-		<posX>139</posX>
+		<posX>141.4</posX>
 		<posY>-36</posY>
-		<posZ>-147</posZ>
+		<posZ>-29.8</posZ>
 		<scaleX>2.304063</scaleX>
 		<scaleY>2.141902</scaleY>
 		<scaleZ>1.419363</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_03.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_03.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>72</height>
+	<width>72</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>212.9582</posX>
+		<posX>333.9971</posX>
 		<posY>-61.7</posY>
-		<posZ>261.0686</posZ>
+		<posZ>364.9032</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>215.3003</posX>
+		<posX>336.3392</posX>
 		<posY>-63.4</posY>
-		<posZ>221.3652</posZ>
+		<posZ>325.1998</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>22.26144</posX>
+		<posX>143.3003</posX>
 		<posY>-64</posY>
-		<posZ>255.8804</posZ>
+		<posZ>359.715</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,13 +50,13 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>-24.21449</posX>
+		<posX>96.8244</posX>
 		<posY>-63.4</posY>
-		<posZ>157.1634</posZ>
+		<posZ>260.998</posZ>
 		<scaleX>274.0285</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>539.3344</scaleZ>
-		<rotW>0.07581899</rotW>
+		<rotW>0.075819</rotW>
 		<rotX>0</rotX>
 		<rotY>-0.9971216</rotY>
 		<rotZ>0</rotZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>12.45205</posX>
+		<posX>133.491</posX>
 		<posY>-63.4</posY>
-		<posZ>26.1963</posZ>
+		<posZ>130.0309</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>214.9611</posX>
+		<posX>336</posX>
 		<posY>-63.4</posY>
-		<posZ>31.16542</posZ>
+		<posZ>135</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>212.6517</posX>
+		<posX>333.6906</posX>
 		<posY>-63.4</posY>
-		<posZ>89.16983</posZ>
+		<posZ>193.0044</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>93.74127</posX>
+		<posX>214.7802</posX>
 		<posY>-58.3</posY>
-		<posZ>4.071014</posZ>
+		<posZ>107.9056</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>7</objectID>
 		<name>60711</name>
-		<posX>96.46507</posX>
+		<posX>217.504</posX>
 		<posY>-0.2999992</posY>
-		<posZ>128.857</posZ>
+		<posZ>232.6916</posZ>
 		<scaleX>332.6481</scaleX>
 		<scaleY>39.89067</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>47</objectID>
 		<name>60711</name>
-		<posX>90.76</posX>
+		<posX>211.7989</posX>
 		<posY>-40.36</posY>
-		<posZ>-26.87</posZ>
+		<posZ>76.96458</posZ>
 		<scaleX>243.2526</scaleX>
 		<scaleY>478.7601</scaleY>
 		<scaleZ>184.0589</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>228</objectID>
 		<name>60711</name>
-		<posX>-76</posX>
+		<posX>45.03889</posX>
 		<posY>-205.7</posY>
-		<posZ>120.06</posZ>
+		<posZ>223.8946</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>229</objectID>
 		<name>60711</name>
-		<posX>81</posX>
+		<posX>202.0389</posX>
 		<posY>-198.1</posY>
-		<posZ>249</posZ>
+		<posZ>352.8346</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>230</objectID>
 		<name>60711</name>
-		<posX>81</posX>
+		<posX>202.0389</posX>
 		<posY>-198.1</posY>
-		<posZ>-18.3</posZ>
+		<posZ>85.53458</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>245</posX>
+		<posX>366.0389</posX>
 		<posY>-205.7</posY>
-		<posZ>100</posZ>
+		<posZ>203.8346</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -215,9 +215,9 @@
 		<type>0</type>
 		<objectID>39</objectID>
 		<name>41719</name>
-		<posX>196.34</posX>
+		<posX>317.3789</posX>
 		<posY>-44.7</posY>
-		<posZ>153.56</posZ>
+		<posZ>257.3946</posZ>
 		<scaleX>6.419933</scaleX>
 		<scaleY>28.72858</scaleY>
 		<scaleZ>14.96578</scaleZ>
@@ -230,9 +230,9 @@
 		<type>0</type>
 		<objectID>45</objectID>
 		<name>60711</name>
-		<posX>218.7</posX>
+		<posX>339.7389</posX>
 		<posY>4.1</posY>
-		<posZ>120.5</posZ>
+		<posZ>224.3346</posZ>
 		<scaleX>216.0249</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>523.4564</scaleZ>
@@ -245,9 +245,9 @@
 		<type>0</type>
 		<objectID>48</objectID>
 		<name>60711</name>
-		<posX>63.69728</posX>
+		<posX>184.7362</posX>
 		<posY>4.1</posY>
-		<posZ>66.95528</posZ>
+		<posZ>170.7899</posZ>
 		<scaleX>216.0249</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>523.4564</scaleZ>
@@ -260,9 +260,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>60720</name>
-		<posX>106.5</posX>
+		<posX>227.5389</posX>
 		<posY>-170.7</posY>
-		<posZ>57.8</posZ>
+		<posZ>161.6346</posZ>
 		<scaleX>240.0737</scaleX>
 		<scaleY>609.4603</scaleY>
 		<scaleZ>260.344</scaleZ>
@@ -275,9 +275,9 @@
 		<type>0</type>
 		<objectID>10</objectID>
 		<name>41719</name>
-		<posX>58.65</posX>
+		<posX>179.6889</posX>
 		<posY>-198.7</posY>
-		<posZ>151.2</posZ>
+		<posZ>255.0346</posZ>
 		<scaleX>7.083212</scaleX>
 		<scaleY>49.06013</scaleY>
 		<scaleZ>8.99827</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_03r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_03r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>80</height>
+	<width>80</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>212.9582</posX>
+		<posX>370.4931</posX>
 		<posY>-61.7</posY>
-		<posZ>261.0686</posZ>
+		<posZ>381.2116</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,13 +20,13 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>215.3003</posX>
+		<posX>372.8352</posX>
 		<posY>-63.4</posY>
-		<posZ>221.3652</posZ>
+		<posZ>341.5082</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
-		<rotW>-0.9592205</rotW>
+		<rotW>-0.9592204</rotW>
 		<rotX>0</rotX>
 		<rotY>-0.2826591</rotY>
 		<rotZ>0</rotZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>22.26144</posX>
+		<posX>179.7964</posX>
 		<posY>-64</posY>
-		<posZ>255.8804</posZ>
+		<posZ>376.0234</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>-24.21449</posX>
+		<posX>133.3204</posX>
 		<posY>-63.4</posY>
-		<posZ>157.1634</posZ>
+		<posZ>277.3064</posZ>
 		<scaleX>274.0285</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>539.3344</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>12.45205</posX>
+		<posX>169.987</posX>
 		<posY>-63.4</posY>
-		<posZ>26.1963</posZ>
+		<posZ>146.3393</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,13 +80,13 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>214.9611</posX>
+		<posX>372.496</posX>
 		<posY>-63.4</posY>
-		<posZ>31.16542</posZ>
+		<posZ>151.3084</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
-		<rotW>-0.9592205</rotW>
+		<rotW>-0.9592204</rotW>
 		<rotX>0</rotX>
 		<rotY>-0.2826591</rotY>
 		<rotZ>0</rotZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>212.6517</posX>
+		<posX>370.1866</posX>
 		<posY>-63.4</posY>
-		<posZ>89.16983</posZ>
+		<posZ>209.3128</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>93.74127</posX>
+		<posX>251.2762</posX>
 		<posY>-58.3</posY>
-		<posZ>4.071014</posZ>
+		<posZ>124.214</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>7</objectID>
 		<name>60711</name>
-		<posX>96.46507</posX>
+		<posX>254</posX>
 		<posY>-0.2999992</posY>
-		<posZ>128.857</posZ>
+		<posZ>249</posZ>
 		<scaleX>332.6481</scaleX>
 		<scaleY>39.89067</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>47</objectID>
 		<name>60711</name>
-		<posX>90.76</posX>
+		<posX>248.2949</posX>
 		<posY>-40.36</posY>
-		<posZ>-26.87</posZ>
+		<posZ>93.273</posZ>
 		<scaleX>243.2526</scaleX>
 		<scaleY>478.7601</scaleY>
 		<scaleZ>184.0589</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>228</objectID>
 		<name>60711</name>
-		<posX>-76</posX>
+		<posX>81.53493</posX>
 		<posY>-205.7</posY>
-		<posZ>120.06</posZ>
+		<posZ>240.203</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>229</objectID>
 		<name>60711</name>
-		<posX>81</posX>
+		<posX>238.5349</posX>
 		<posY>-198.1</posY>
-		<posZ>249</posZ>
+		<posZ>369.143</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>230</objectID>
 		<name>60711</name>
-		<posX>81</posX>
+		<posX>238.5349</posX>
 		<posY>-198.1</posY>
-		<posZ>-18.3</posZ>
+		<posZ>101.843</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>245</posX>
+		<posX>402.5349</posX>
 		<posY>-205.7</posY>
-		<posZ>100</posZ>
+		<posZ>220.143</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -215,9 +215,9 @@
 		<type>0</type>
 		<objectID>39</objectID>
 		<name>41719</name>
-		<posX>196.34</posX>
+		<posX>353.8749</posX>
 		<posY>-44.7</posY>
-		<posZ>153.56</posZ>
+		<posZ>273.703</posZ>
 		<scaleX>6.419933</scaleX>
 		<scaleY>28.72858</scaleY>
 		<scaleZ>14.96578</scaleZ>
@@ -230,9 +230,9 @@
 		<type>0</type>
 		<objectID>45</objectID>
 		<name>60711</name>
-		<posX>218.7</posX>
+		<posX>376.2349</posX>
 		<posY>4.1</posY>
-		<posZ>120.5</posZ>
+		<posZ>240.643</posZ>
 		<scaleX>216.0249</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>523.4564</scaleZ>
@@ -245,9 +245,9 @@
 		<type>0</type>
 		<objectID>48</objectID>
 		<name>60711</name>
-		<posX>63.69728</posX>
+		<posX>221.2322</posX>
 		<posY>4.1</posY>
-		<posZ>66.95528</posZ>
+		<posZ>187.0983</posZ>
 		<scaleX>216.0249</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>523.4564</scaleZ>
@@ -260,9 +260,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>60720</name>
-		<posX>101</posX>
+		<posX>258.5349</posX>
 		<posY>-140</posY>
-		<posZ>81</posZ>
+		<posZ>201.143</posZ>
 		<scaleX>240.0737</scaleX>
 		<scaleY>609.4603</scaleY>
 		<scaleZ>260.344</scaleZ>
@@ -275,9 +275,9 @@
 		<type>0</type>
 		<objectID>10</objectID>
 		<name>41719</name>
-		<posX>187.4</posX>
+		<posX>344.9349</posX>
 		<posY>-92.1</posY>
-		<posZ>38</posZ>
+		<posZ>158.143</posZ>
 		<scaleX>7.083212</scaleX>
 		<scaleY>34.06932</scaleY>
 		<scaleZ>8.99827</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_04.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_04.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>72</height>
+	<width>72</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>112.1101</posX>
+		<posX>252.9611</posX>
 		<posY>-61.7</posY>
-		<posZ>252.9001</posZ>
+		<posZ>366.8922</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>134.0491</posX>
+		<posX>274.9001</posX>
 		<posY>-63.4</posY>
-		<posZ>219.726</posZ>
+		<posZ>333.7181</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>-50.26581</posX>
+		<posX>90.58519</posX>
 		<posY>-64</posY>
-		<posZ>152.7689</posZ>
+		<posZ>266.761</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>-40.96301</posX>
+		<posX>99.88799</posX>
 		<posY>-63.4</posY>
-		<posZ>44.05578</posZ>
+		<posZ>158.0479</posZ>
 		<scaleX>274.0285</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>539.3344</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>229.149</posX>
+		<posX>370</posX>
 		<posY>-63.4</posY>
-		<posZ>55.00793</posZ>
+		<posZ>169</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>198.0595</posX>
+		<posX>338.9105</posX>
 		<posY>-63.4</posY>
-		<posZ>104.031</posZ>
+		<posZ>218.0231</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>137.8669</posX>
+		<posX>278.7179</posX>
 		<posY>-58.3</posY>
-		<posZ>-29.22939</posZ>
+		<posZ>84.76268</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>39</objectID>
 		<name>60711</name>
-		<posX>181.5095</posX>
+		<posX>322.3605</posX>
 		<posY>-11.124</posY>
-		<posZ>32.12202</posZ>
+		<posZ>146.1141</posZ>
 		<scaleX>266.687</scaleX>
 		<scaleY>316.7958</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>47</objectID>
 		<name>60711</name>
-		<posX>-30.30175</posX>
+		<posX>110.5492</posX>
 		<posY>-1.834272</posY>
-		<posZ>111.79</posZ>
+		<posZ>225.7821</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>228</objectID>
 		<name>60711</name>
-		<posX>241.3712</posX>
+		<posX>382.2222</posX>
 		<posY>-205.7</posY>
-		<posZ>183.2386</posZ>
+		<posZ>297.2307</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>229</objectID>
 		<name>60711</name>
-		<posX>169.8751</posX>
+		<posX>310.7261</posX>
 		<posY>-198.1</posY>
-		<posZ>-6.926689</posZ>
+		<posZ>107.0654</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>230</objectID>
 		<name>60711</name>
-		<posX>36.2252</posX>
+		<posX>177.0762</posX>
 		<posY>-198.1</posY>
-		<posZ>224.562</posZ>
+		<posZ>338.5541</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>-46.65311</posX>
+		<posX>94.19789</posX>
 		<posY>-205.7</posY>
-		<posZ>40.11125</posZ>
+		<posZ>154.1033</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>60714</name>
-		<posX>-9.14</posX>
+		<posX>131.711</posX>
 		<posY>-46</posY>
-		<posZ>91.26</posZ>
+		<posZ>205.2521</posZ>
 		<scaleX>244.7696</scaleX>
 		<scaleY>544.4368</scaleY>
 		<scaleZ>231.6121</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_04r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_04r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>76</height>
+	<width>80</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>112.1101</posX>
+		<posX>271.6006</posX>
 		<posY>-61.7</posY>
-		<posZ>252.9001</posZ>
+		<posZ>374.7781</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>134.0491</posX>
+		<posX>293.5396</posX>
 		<posY>-63.4</posY>
-		<posZ>219.726</posZ>
+		<posZ>341.604</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>-50.26581</posX>
+		<posX>109.2247</posX>
 		<posY>-64</posY>
-		<posZ>152.7689</posZ>
+		<posZ>274.6469</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>-40.96301</posX>
+		<posX>118.5275</posX>
 		<posY>-63.4</posY>
-		<posZ>44.05578</posZ>
+		<posZ>165.9337</posZ>
 		<scaleX>274.0285</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>539.3344</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>229.149</posX>
+		<posX>388.6395</posX>
 		<posY>-63.4</posY>
-		<posZ>55.00793</posZ>
+		<posZ>176.8859</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>198.0595</posX>
+		<posX>357.55</posX>
 		<posY>-63.4</posY>
-		<posZ>104.031</posZ>
+		<posZ>225.909</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>137.8669</posX>
+		<posX>297.3574</posX>
 		<posY>-58.3</posY>
-		<posZ>-29.22939</posZ>
+		<posZ>92.64859</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>39</objectID>
 		<name>60711</name>
-		<posX>181.5095</posX>
+		<posX>341</posX>
 		<posY>-42.7</posY>
-		<posZ>32.12202</posZ>
+		<posZ>154</posZ>
 		<scaleX>266.687</scaleX>
 		<scaleY>316.7958</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>47</objectID>
 		<name>60711</name>
-		<posX>-30.30175</posX>
+		<posX>129.1888</posX>
 		<posY>-1.834272</posY>
-		<posZ>111.79</posZ>
+		<posZ>233.668</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>228</objectID>
 		<name>60711</name>
-		<posX>241.3712</posX>
+		<posX>400.8617</posX>
 		<posY>-205.7</posY>
-		<posZ>183.2386</posZ>
+		<posZ>305.1166</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -155,9 +155,9 @@
 		<type>0</type>
 		<objectID>229</objectID>
 		<name>60711</name>
-		<posX>169.8751</posX>
+		<posX>329.3656</posX>
 		<posY>-198.1</posY>
-		<posZ>-6.926689</posZ>
+		<posZ>114.9513</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>230</objectID>
 		<name>60711</name>
-		<posX>36.2252</posX>
+		<posX>195.7157</posX>
 		<posY>-198.1</posY>
-		<posZ>224.562</posZ>
+		<posZ>346.44</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>-46.65311</posX>
+		<posX>112.8374</posX>
 		<posY>-205.7</posY>
-		<posZ>40.11125</posZ>
+		<posZ>161.9892</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>60714</name>
-		<posX>46.6</posX>
+		<posX>206.0905</posX>
 		<posY>-63</posY>
-		<posZ>127.9</posZ>
+		<posZ>249.778</posZ>
 		<scaleX>244.7696</scaleX>
 		<scaleY>544.4368</scaleY>
 		<scaleZ>231.6121</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Large_04r2.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Large_04r2.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>80</height>
+	<width>80</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>112.1101</posX>
+		<posX>289.7389</posX>
 		<posY>-61.7</posY>
-		<posZ>252.9001</posZ>
+		<posZ>402.6615</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>134.0491</posX>
+		<posX>311.6779</posX>
 		<posY>-63.4</posY>
-		<posZ>219.726</posZ>
+		<posZ>369.4874</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>-50.26581</posX>
+		<posX>127.363</posX>
 		<posY>-64</posY>
-		<posZ>152.7689</posZ>
+		<posZ>302.5303</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>-40.96301</posX>
+		<posX>136.6658</posX>
 		<posY>-63.4</posY>
-		<posZ>44.05578</posZ>
+		<posZ>193.8172</posZ>
 		<scaleX>274.0285</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>539.3344</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>229.149</posX>
+		<posX>406.7778</posX>
 		<posY>-63.4</posY>
-		<posZ>55.00793</posZ>
+		<posZ>204.7693</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>198.0595</posX>
+		<posX>375.6883</posX>
 		<posY>-63.4</posY>
-		<posZ>104.031</posZ>
+		<posZ>253.7924</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>137.8669</posX>
+		<posX>315.4957</posX>
 		<posY>-58.3</posY>
-		<posZ>-29.22939</posZ>
+		<posZ>120.532</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>39</objectID>
 		<name>60711</name>
-		<posX>181.5095</posX>
+		<posX>359.1383</posX>
 		<posY>-11.124</posY>
-		<posZ>32.12202</posZ>
+		<posZ>181.8834</posZ>
 		<scaleX>266.687</scaleX>
 		<scaleY>316.7958</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>47</objectID>
 		<name>60711</name>
-		<posX>-30.30175</posX>
+		<posX>147.3271</posX>
 		<posY>-1.834272</posY>
-		<posZ>111.79</posZ>
+		<posZ>261.5514</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>228</objectID>
 		<name>60711</name>
-		<posX>241.3712</posX>
+		<posX>419</posX>
 		<posY>-205.7</posY>
-		<posZ>183.2386</posZ>
+		<posZ>333</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -155,13 +155,13 @@
 		<type>0</type>
 		<objectID>229</objectID>
 		<name>60711</name>
-		<posX>169.8751</posX>
+		<posX>347.5039</posX>
 		<posY>-198.1</posY>
-		<posZ>-6.926689</posZ>
+		<posZ>142.8347</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
-		<rotW>-0.9812364</rotW>
+		<rotW>-0.9812365</rotW>
 		<rotX>-0.0009708105</rotX>
 		<rotY>0.03947747</rotY>
 		<rotZ>-0.1887211</rotZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>230</objectID>
 		<name>60711</name>
-		<posX>36.2252</posX>
+		<posX>213.854</posX>
 		<posY>-198.1</posY>
-		<posZ>224.562</posZ>
+		<posZ>374.3234</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>-46.65311</posX>
+		<posX>130.9757</posX>
 		<posY>-205.7</posY>
-		<posZ>40.11125</posZ>
+		<posZ>189.8727</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>60714</name>
-		<posX>-9.14</posX>
+		<posX>168.4888</posX>
 		<posY>-75.1</posY>
-		<posZ>91.26</posZ>
+		<posZ>241.0214</posZ>
 		<scaleX>244.7696</scaleX>
 		<scaleY>544.4368</scaleY>
 		<scaleZ>231.6121</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Medium_03.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Medium_03.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>32</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>-6.878414</posX>
+		<posX>65.35699</posX>
 		<posY>-67.17999</posY>
-		<posZ>43.28382</posZ>
+		<posZ>110.3667</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>28.70836</posX>
+		<posX>100.9438</posX>
 		<posY>-67.17999</posY>
-		<posZ>25.52376</posZ>
+		<posZ>92.60663</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>66.37312</posX>
+		<posX>138.6085</posX>
 		<posY>-148.78</posY>
-		<posZ>-81.43886</posZ>
+		<posZ>-14.35599</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>-49.92063</posX>
+		<posX>22.31478</posX>
 		<posY>-144.68</posY>
-		<posZ>68.13429</posZ>
+		<posZ>135.2172</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>52.66459</posX>
+		<posX>124.9</posX>
 		<posY>-150.48</posY>
-		<posZ>65.61713</posZ>
+		<posZ>132.7</posZ>
 		<scaleX>549.5283</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60712</name>
-		<posX>17.52</posX>
+		<posX>89.75542</posX>
 		<posY>-36.1</posY>
-		<posZ>31.1</posZ>
+		<posZ>98.18287</posZ>
 		<scaleX>145.21</scaleX>
 		<scaleY>363.0534</scaleY>
 		<scaleZ>173.0957</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Medium_03r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Medium_03r1.txt
@@ -1,17 +1,17 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>32</height>
+	<width>40</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>-6.878414</posX>
+		<posX>105.7</posX>
 		<posY>-67.17999</posY>
-		<posZ>43.28382</posZ>
+		<posZ>112.2</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
-		<rotW>0.8791356</rotW>
+		<rotW>0.8791357</rotW>
 		<rotX>0</rotX>
 		<rotY>0.4765716</rotY>
 		<rotZ>0</rotZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>28.70836</posX>
+		<posX>141.2868</posX>
 		<posY>-67.17999</posY>
-		<posZ>25.52376</posZ>
+		<posZ>94.43993</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>66.37312</posX>
+		<posX>178.9515</posX>
 		<posY>-148.78</posY>
-		<posZ>-81.43886</posZ>
+		<posZ>-12.52268</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,13 +50,13 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>-49.92063</posX>
+		<posX>62.65778</posX>
 		<posY>-144.68</posY>
-		<posZ>68.13429</posZ>
+		<posZ>137.0505</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
-		<rotW>0.8791356</rotW>
+		<rotW>0.8791357</rotW>
 		<rotX>0</rotX>
 		<rotY>0.4765716</rotY>
 		<rotZ>0</rotZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>52.66459</posX>
+		<posX>165.243</posX>
 		<posY>-150.48</posY>
-		<posZ>65.61713</posZ>
+		<posZ>134.5333</posZ>
 		<scaleX>549.5283</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60712</name>
-		<posX>3.6</posX>
+		<posX>116.1784</posX>
 		<posY>-32.3</posY>
-		<posZ>40.5</posZ>
+		<posZ>109.4162</posZ>
 		<scaleX>145.21</scaleX>
 		<scaleY>363.0534</scaleY>
 		<scaleZ>173.0957</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Medium_04.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Medium_04.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>64</height>
+	<width>72</width>
 	<object>
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>-70.88227</posX>
+		<posX>145.7</posX>
 		<posY>-49.77</posY>
-		<posZ>-19.56162</posZ>
+		<posZ>115</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>0.5050697</posX>
+		<posX>217.0873</posX>
 		<posY>-45.66999</posY>
-		<posZ>155.9383</posZ>
+		<posZ>290.4999</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>60.973</posX>
+		<posX>277.5553</posX>
 		<posY>-61.137</posY>
-		<posZ>50.313</posZ>
+		<posZ>184.8746</posZ>
 		<scaleX>497.7188</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-24.1</posX>
+		<posX>192.4823</posX>
 		<posY>26.267</posY>
-		<posZ>94.8</posZ>
+		<posZ>229.3616</posZ>
 		<scaleX>300.6916</scaleX>
 		<scaleY>149.4252</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -65,24 +65,24 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>51</posX>
+		<posX>267.5823</posX>
 		<posY>11.234</posY>
-		<posZ>16</posZ>
+		<posZ>150.5616</posZ>
 		<scaleX>300.6916</scaleX>
 		<scaleY>321.2193</scaleY>
 		<scaleZ>284.0433</scaleZ>
-		<rotW>0.7981246</rotW>
+		<rotW>0.7981245</rotW>
 		<rotX>0</rotX>
-		<rotY>0.6024926</rotY>
+		<rotY>0.6024925</rotY>
 		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>128.1377</posX>
+		<posX>344.72</posX>
 		<posY>25.37717</posY>
-		<posZ>68.77291</posZ>
+		<posZ>203.3345</posZ>
 		<scaleX>199.4668</scaleX>
 		<scaleY>169.2569</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>-12</posX>
+		<posX>204.5823</posX>
 		<posY>-225</posY>
-		<posZ>80</posZ>
+		<posZ>214.5616</posZ>
 		<scaleX>590.0792</scaleX>
 		<scaleY>663.0609</scaleY>
 		<scaleZ>900.9778</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Medium_04r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Medium_04r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>1</height>
-	<width>1</width>
+	<height>80</height>
+	<width>80</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>112.1101</posX>
+		<posX>292.0506</posX>
 		<posY>-61.7</posY>
-		<posZ>252.9001</posZ>
+		<posZ>404.8691</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>134.0491</posX>
+		<posX>313.9896</posX>
 		<posY>-63.4</posY>
-		<posZ>219.726</posZ>
+		<posZ>371.695</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>-50.26581</posX>
+		<posX>129.6747</posX>
 		<posY>-64</posY>
-		<posZ>152.7689</posZ>
+		<posZ>304.7379</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>476.7354</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>-40.96301</posX>
+		<posX>138.9775</posX>
 		<posY>-63.4</posY>
-		<posZ>44.05578</posZ>
+		<posZ>196.0248</posZ>
 		<scaleX>274.0285</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>539.3344</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60711</name>
-		<posX>229.149</posX>
+		<posX>409.0895</posX>
 		<posY>-63.4</posY>
-		<posZ>55.00793</posZ>
+		<posZ>206.9769</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>198.0595</posX>
+		<posX>378</posX>
 		<posY>-63.4</posY>
-		<posZ>104.031</posZ>
+		<posZ>256</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>137.8669</posX>
+		<posX>317.8074</posX>
 		<posY>-58.3</posY>
-		<posZ>-29.22939</posZ>
+		<posZ>122.7396</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -110,9 +110,9 @@
 		<type>0</type>
 		<objectID>39</objectID>
 		<name>60711</name>
-		<posX>181.5095</posX>
+		<posX>361.45</posX>
 		<posY>-11.124</posY>
-		<posZ>32.12202</posZ>
+		<posZ>184.091</posZ>
 		<scaleX>266.687</scaleX>
 		<scaleY>316.7958</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -125,9 +125,9 @@
 		<type>0</type>
 		<objectID>47</objectID>
 		<name>60711</name>
-		<posX>-15</posX>
+		<posX>164.9405</posX>
 		<posY>-13.5</posY>
-		<posZ>65.6</posZ>
+		<posZ>217.569</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>280.8436</scaleZ>
@@ -140,9 +140,9 @@
 		<type>0</type>
 		<objectID>228</objectID>
 		<name>60711</name>
-		<posX>241.3712</posX>
+		<posX>421.3117</posX>
 		<posY>-205.7</posY>
-		<posZ>183.2386</posZ>
+		<posZ>335.2076</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -155,13 +155,13 @@
 		<type>0</type>
 		<objectID>229</objectID>
 		<name>60711</name>
-		<posX>169.8751</posX>
+		<posX>349.8156</posX>
 		<posY>-198.1</posY>
-		<posZ>-6.926689</posZ>
+		<posZ>145.0423</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
-		<rotW>-0.9812364</rotW>
+		<rotW>-0.9812365</rotW>
 		<rotX>-0.0009708105</rotX>
 		<rotY>0.03947747</rotY>
 		<rotZ>-0.1887211</rotZ>
@@ -170,9 +170,9 @@
 		<type>0</type>
 		<objectID>230</objectID>
 		<name>60711</name>
-		<posX>36.2252</posX>
+		<posX>216.1657</posX>
 		<posY>-198.1</posY>
-		<posZ>224.562</posZ>
+		<posZ>376.531</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -185,9 +185,9 @@
 		<type>0</type>
 		<objectID>232</objectID>
 		<name>60711</name>
-		<posX>-46.65311</posX>
+		<posX>133.2874</posX>
 		<posY>-205.7</posY>
-		<posZ>40.11125</posZ>
+		<posZ>192.0802</posZ>
 		<scaleX>480.1978</scaleX>
 		<scaleY>376.7465</scaleY>
 		<scaleZ>745.4336</scaleZ>
@@ -200,9 +200,9 @@
 		<type>0</type>
 		<objectID>9</objectID>
 		<name>60714</name>
-		<posX>-9.14</posX>
+		<posX>170.8005</posX>
 		<posY>-88.5</posY>
-		<posZ>91.26</posZ>
+		<posZ>243.229</posZ>
 		<scaleX>244.7696</scaleX>
 		<scaleY>544.4368</scaleY>
 		<scaleZ>231.6121</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Medium_05r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Medium_05r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>32</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60719</name>
-		<posX>-18.553</posX>
+		<posX>91.275</posX>
 		<posY>-5.5798</posY>
-		<posZ>-23.137</posZ>
+		<posZ>64.98</posZ>
 		<scaleX>86.69106</scaleX>
 		<scaleY>64.77064</scaleY>
 		<scaleZ>68.3052</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60719</name>
-		<posX>-14.815</posX>
+		<posX>95.013</posX>
 		<posY>-47.7</posY>
-		<posZ>-7.0235</posZ>
+		<posZ>81.09351</posZ>
 		<scaleX>117.1666</scaleX>
 		<scaleY>105.3318</scaleY>
 		<scaleZ>111.0798</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60719</name>
-		<posX>-77.628</posX>
+		<posX>32.2</posX>
 		<posY>-23.967</posY>
-		<posZ>-29.617</posZ>
+		<posZ>58.5</posZ>
 		<scaleX>40.21608</scaleX>
 		<scaleY>57.42638</scaleY>
 		<scaleZ>49.14267</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60719</name>
-		<posX>-61.807</posX>
+		<posX>48.021</posX>
 		<posY>-30.674</posY>
-		<posZ>-55.577</posZ>
+		<posZ>32.54</posZ>
 		<scaleX>50.95125</scaleX>
 		<scaleY>57.42638</scaleY>
 		<scaleZ>77.52333</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>51.2</posX>
+		<posX>161.028</posX>
 		<posY>-27.4</posY>
-		<posZ>11.6</posZ>
+		<posZ>99.717</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>25.4</posX>
+		<posX>135.228</posX>
 		<posY>-26</posY>
-		<posZ>-42.5</posZ>
+		<posZ>45.617</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>-13.9</posX>
+		<posX>95.928</posX>
 		<posY>-3.299999</posY>
-		<posZ>36.4</posZ>
+		<posZ>124.517</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_01.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_01.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>48</height>
+	<width>48</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>1.112739</posX>
+		<posX>153.9127</posX>
 		<posY>-21</posY>
-		<posZ>-4.899077</posZ>
+		<posZ>113.4009</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-1.3</posX>
+		<posX>151.5</posX>
 		<posY>-21</posY>
-		<posZ>34.8</posZ>
+		<posZ>153.1</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>72.5</posX>
+		<posX>225.3</posX>
 		<posY>-102.6</posY>
-		<posZ>120.9</posZ>
+		<posZ>239.2</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>1.1127</posX>
+		<posX>153.9127</posX>
 		<posY>-98.5</posY>
-		<posZ>-54.6</posZ>
+		<posZ>63.7</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>-48</posX>
+		<posX>104.8</posX>
 		<posY>-104.3</posY>
-		<posZ>35.5</posZ>
+		<posZ>153.8</posZ>
 		<scaleX>549.5283</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_01r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_01r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>52</height>
+	<width>36</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>1.112739</posX>
+		<posX>119.4127</posX>
 		<posY>-21</posY>
-		<posZ>-4.899077</posZ>
+		<posZ>137.7009</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-1.3</posX>
+		<posX>117</posX>
 		<posY>-21</posY>
-		<posZ>34.8</posZ>
+		<posZ>177.4</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>72.5</posX>
+		<posX>190.8</posX>
 		<posY>-102.6</posY>
-		<posZ>120.9</posZ>
+		<posZ>263.5</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>1.1127</posX>
+		<posX>119.4127</posX>
 		<posY>-98.5</posY>
-		<posZ>-54.6</posZ>
+		<posZ>88.00001</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>-48</posX>
+		<posX>70.3</posX>
 		<posY>-104.3</posY>
-		<posZ>35.5</posZ>
+		<posZ>178.1</posZ>
 		<scaleX>549.5283</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_02.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_02.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>2</height>
-	<width>1</width>
+	<height>32</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>-4.687261</posX>
+		<posX>107.1127</posX>
 		<posY>-71.49</posY>
-		<posZ>-2.499081</posZ>
+		<posZ>71.60092</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-7.099999</posX>
+		<posX>104.7</posX>
 		<posY>-71.49</posY>
-		<posZ>37.2</posZ>
+		<posZ>111.3</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>19</objectID>
 		<name>60711</name>
-		<posX>-4.687261</posX>
+		<posX>107.1127</posX>
 		<posY>-165.89</posY>
-		<posZ>-62.3</posZ>
+		<posZ>11.80001</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>20</objectID>
 		<name>60711</name>
-		<posX>62.1</posX>
+		<posX>173.9</posX>
 		<posY>-163.79</posY>
-		<posZ>71.7</posZ>
+		<posZ>145.8</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -65,15 +65,15 @@
 		<type>0</type>
 		<objectID>21</objectID>
 		<name>60711</name>
-		<posX>-85.7</posX>
+		<posX>26.1</posX>
 		<posY>-149.89</posY>
-		<posZ>34.409</posZ>
+		<posZ>108.509</posZ>
 		<scaleX>251.2879</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>626.2794</scaleZ>
 		<rotW>-0.172935</rotW>
 		<rotX>0</rotX>
-		<rotY>0.9849332</rotY>
+		<rotY>0.9849333</rotY>
 		<rotZ>0</rotZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_02r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_02r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>2</height>
-	<width>1</width>
+	<height>40</height>
+	<width>24</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>-4.687261</posX>
+		<posX>83.41273</posX>
 		<posY>-71.49</posY>
-		<posZ>-2.499081</posZ>
+		<posZ>104.7009</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-7.099999</posX>
+		<posX>81</posX>
 		<posY>-71.49</posY>
-		<posZ>37.2</posZ>
+		<posZ>144.4</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>19</objectID>
 		<name>60711</name>
-		<posX>-4.687261</posX>
+		<posX>83.41273</posX>
 		<posY>-165.89</posY>
-		<posZ>-62.3</posZ>
+		<posZ>44.9</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>20</objectID>
 		<name>60711</name>
-		<posX>62.1</posX>
+		<posX>150.2</posX>
 		<posY>-163.79</posY>
-		<posZ>71.7</posZ>
+		<posZ>178.9</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>21</objectID>
 		<name>60711</name>
-		<posX>-85.7</posX>
+		<posX>2.400002</posX>
 		<posY>-149.89</posY>
-		<posZ>34.409</posZ>
+		<posZ>141.609</posZ>
 		<scaleX>251.2879</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>626.2794</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_03.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_03.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>32</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>-6.878414</posX>
+		<posX>67.94221</posX>
 		<posY>-67.17999</posY>
-		<posZ>43.28382</posZ>
+		<posZ>105.9495</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>28.70836</posX>
+		<posX>103.529</posX>
 		<posY>-67.17999</posY>
-		<posZ>25.52376</posZ>
+		<posZ>88.18947</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>66.37312</posX>
+		<posX>141.1938</posX>
 		<posY>-148.78</posY>
-		<posZ>-81.43886</posZ>
+		<posZ>-18.77315</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>-49.92063</posX>
+		<posX>24.9</posX>
 		<posY>-144.68</posY>
-		<posZ>68.13429</posZ>
+		<posZ>130.8</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>52.66459</posX>
+		<posX>127.4852</posX>
 		<posY>-150.48</posY>
-		<posZ>65.61713</posZ>
+		<posZ>128.2828</posZ>
 		<scaleX>549.5283</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60712</name>
-		<posX>17.52</posX>
+		<posX>92.34064</posX>
 		<posY>-46.1</posY>
-		<posZ>31.1</posZ>
+		<posZ>93.76571</posZ>
 		<scaleX>145.21</scaleX>
 		<scaleY>363.0534</scaleY>
 		<scaleZ>173.0957</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_03r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_03r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>32</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>8</objectID>
 		<name>60711</name>
-		<posX>-6.878414</posX>
+		<posX>80.9</posX>
 		<posY>-67.17999</posY>
-		<posZ>43.28382</posZ>
+		<posZ>104.5</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>28.70836</posX>
+		<posX>116.4868</posX>
 		<posY>-67.17999</posY>
-		<posZ>25.52376</posZ>
+		<posZ>86.73994</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>66.37312</posX>
+		<posX>154.1515</posX>
 		<posY>-148.78</posY>
-		<posZ>-81.43886</posZ>
+		<posZ>-20.22268</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>-49.92063</posX>
+		<posX>37.85778</posX>
 		<posY>-144.68</posY>
-		<posZ>68.13429</posZ>
+		<posZ>129.3505</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>52.66459</posX>
+		<posX>140.443</posX>
 		<posY>-150.48</posY>
-		<posZ>65.61713</posZ>
+		<posZ>126.8333</posZ>
 		<scaleX>549.5283</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>15</objectID>
 		<name>60712</name>
-		<posX>17.52</posX>
+		<posX>105.2984</posX>
 		<posY>-59.3</posY>
-		<posZ>31.1</posZ>
+		<posZ>92.31618</posZ>
 		<scaleX>145.21</scaleX>
 		<scaleY>363.0534</scaleY>
 		<scaleZ>173.0957</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_04.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_04.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>64</height>
+	<width>72</width>
 	<object>
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>-70.88227</posX>
+		<posX>145.9447</posX>
 		<posY>-49.77</posY>
-		<posZ>-19.56162</posZ>
+		<posZ>122.5254</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>0.5050697</posX>
+		<posX>217.3321</posX>
 		<posY>-45.66999</posY>
-		<posZ>155.9383</posZ>
+		<posZ>298.0253</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>60.973</posX>
+		<posX>277.8</posX>
 		<posY>-61.137</posY>
-		<posZ>50.313</posZ>
+		<posZ>192.4</posZ>
 		<scaleX>497.7188</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-24.1</posX>
+		<posX>192.727</posX>
 		<posY>26.267</posY>
-		<posZ>94.8</posZ>
+		<posZ>236.887</posZ>
 		<scaleX>300.6916</scaleX>
 		<scaleY>149.4252</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -65,24 +65,24 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>51</posX>
+		<posX>267.827</posX>
 		<posY>11.234</posY>
-		<posZ>16</posZ>
+		<posZ>158.087</posZ>
 		<scaleX>300.6916</scaleX>
 		<scaleY>321.2193</scaleY>
 		<scaleZ>284.0433</scaleZ>
-		<rotW>0.7981246</rotW>
+		<rotW>0.7981245</rotW>
 		<rotX>0</rotX>
-		<rotY>0.6024926</rotY>
+		<rotY>0.6024925</rotY>
 		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>128.1377</posX>
+		<posX>344.9647</posX>
 		<posY>25.37717</posY>
-		<posZ>68.77291</posZ>
+		<posZ>210.8599</posZ>
 		<scaleX>199.4668</scaleX>
 		<scaleY>169.2569</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>-12</posX>
+		<posX>204.827</posX>
 		<posY>-225</posY>
-		<posZ>80</posZ>
+		<posZ>222.087</posZ>
 		<scaleX>590.0792</scaleX>
 		<scaleY>663.0609</scaleY>
 		<scaleZ>900.9778</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_04r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_04r1.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>72</height>
+	<width>64</width>
 	<object>
 		<type>0</type>
 		<objectID>12</objectID>
 		<name>60711</name>
-		<posX>-70.88227</posX>
+		<posX>120.08</posX>
 		<posY>-49.77</posY>
-		<posZ>-19.56162</posZ>
+		<posZ>124.4655</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>406.7014</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>13</objectID>
 		<name>60711</name>
-		<posX>0.5050697</posX>
+		<posX>191.4674</posX>
 		<posY>-45.66999</posY>
-		<posZ>155.9383</posZ>
+		<posZ>299.9654</posZ>
 		<scaleX>223.8246</scaleX>
 		<scaleY>221.6764</scaleY>
 		<scaleZ>676.5477</scaleZ>
@@ -35,24 +35,24 @@
 		<type>0</type>
 		<objectID>14</objectID>
 		<name>60711</name>
-		<posX>60.973</posX>
+		<posX>251.9353</posX>
 		<posY>-61.137</posY>
-		<posZ>50.313</posZ>
+		<posZ>194.3401</posZ>
 		<scaleX>497.7188</scaleX>
 		<scaleY>218.1091</scaleY>
 		<scaleZ>572.3102</scaleZ>
-		<rotW>-0.5489718</rotW>
+		<rotW>-0.5489717</rotW>
 		<rotX>-0.06425741</rotX>
-		<rotY>0.7982097</rotY>
+		<rotY>0.7982096</rotY>
 		<rotZ>0.2395044</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60711</name>
-		<posX>-24.1</posX>
+		<posX>166.8623</posX>
 		<posY>26.267</posY>
-		<posZ>94.8</posZ>
+		<posZ>238.8271</posZ>
 		<scaleX>300.6916</scaleX>
 		<scaleY>149.4252</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -65,9 +65,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60711</name>
-		<posX>51</posX>
+		<posX>241.9623</posX>
 		<posY>11.234</posY>
-		<posZ>16</posZ>
+		<posZ>160.0271</posZ>
 		<scaleX>300.6916</scaleX>
 		<scaleY>321.2193</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -80,9 +80,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60711</name>
-		<posX>128.1377</posX>
+		<posX>319.1</posX>
 		<posY>25.37717</posY>
-		<posZ>68.77291</posZ>
+		<posZ>212.8</posZ>
 		<scaleX>199.4668</scaleX>
 		<scaleY>169.2569</scaleY>
 		<scaleZ>284.0433</scaleZ>
@@ -95,9 +95,9 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>-12</posX>
+		<posX>178.9623</posX>
 		<posY>-225</posY>
-		<posZ>80</posZ>
+		<posZ>224.0271</posZ>
 		<scaleX>590.0792</scaleX>
 		<scaleY>663.0609</scaleY>
 		<scaleZ>900.9778</scaleZ>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_05.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_05.txt
@@ -1,13 +1,13 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>32</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60719</name>
-		<posX>-15.748</posX>
+		<posX>82.852</posX>
 		<posY>-9.1289</posY>
-		<posZ>-15.136</posZ>
+		<posZ>87.964</posZ>
 		<scaleX>140.9794</scaleX>
 		<scaleY>105.3318</scaleY>
 		<scaleZ>111.0798</scaleZ>
@@ -20,9 +20,9 @@
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60719</name>
-		<posX>-14.815</posX>
+		<posX>83.785</posX>
 		<posY>-82.7</posY>
-		<posZ>-7.0235</posZ>
+		<posZ>96.0765</posZ>
 		<scaleX>117.1666</scaleX>
 		<scaleY>105.3318</scaleY>
 		<scaleZ>111.0798</scaleZ>
@@ -35,9 +35,9 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60719</name>
-		<posX>-77.628</posX>
+		<posX>20.972</posX>
 		<posY>-58.967</posY>
-		<posZ>-29.617</posZ>
+		<posZ>73.483</posZ>
 		<scaleX>40.21608</scaleX>
 		<scaleY>57.42638</scaleY>
 		<scaleZ>49.14267</scaleZ>
@@ -50,9 +50,9 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60719</name>
-		<posX>-61.807</posX>
+		<posX>36.793</posX>
 		<posY>-65.674</posY>
-		<posZ>-55.577</posZ>
+		<posZ>47.523</posZ>
 		<scaleX>50.95125</scaleX>
 		<scaleY>57.42638</scaleY>
 		<scaleZ>77.52333</scaleZ>
@@ -65,24 +65,24 @@
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>51.2</posX>
+		<posX>149.8</posX>
 		<posY>-62.4</posY>
-		<posZ>11.6</posZ>
+		<posZ>114.7</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
 		<rotW>0.4396237</rotW>
-		<rotX>-0.09137122</rotX>
+		<rotX>-0.09137123</rotX>
 		<rotY>0.1089189</rotY>
-		<rotZ>-0.886859</rotZ>
+		<rotZ>-0.8868591</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>25.4</posX>
+		<posX>124</posX>
 		<posY>-61</posY>
-		<posZ>-42.5</posZ>
+		<posZ>60.6</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
@@ -95,15 +95,15 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>-13.9</posX>
+		<posX>84.7</posX>
 		<posY>-38.3</posY>
-		<posZ>36.4</posZ>
+		<posZ>139.5</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
 		<rotW>-0.6977761</rotW>
 		<rotX>-0.3286635</rotX>
-		<rotY>-0.5256314</rotY>
+		<rotY>-0.5256315</rotY>
 		<rotZ>-0.3588877</rotZ>
 	</object>
 </locationPrefab>

--- a/Locations/LocationPrefab/WOD_Rocks_Small_05r1.txt
+++ b/Locations/LocationPrefab/WOD_Rocks_Small_05r1.txt
@@ -1,33 +1,33 @@
 <locationPrefab>
-	<height>7</height>
-	<width>5</width>
+	<height>40</height>
+	<width>32</width>
 	<object>
 		<type>0</type>
 		<objectID>4</objectID>
 		<name>60719</name>
-		<posX>-15.748</posX>
+		<posX>112.58</posX>
 		<posY>-9.1289</posY>
-		<posZ>-15.136</posZ>
+		<posZ>144.781</posZ>
 		<scaleX>140.9794</scaleX>
 		<scaleY>105.3318</scaleY>
 		<scaleZ>111.0798</scaleZ>
 		<rotW>-0.2544821</rotW>
 		<rotX>0</rotX>
-		<rotY>-0.9670776</rotY>
+		<rotY>-0.9670775</rotY>
 		<rotZ>0</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>0</objectID>
 		<name>60719</name>
-		<posX>-14.815</posX>
+		<posX>113.513</posX>
 		<posY>-82.7</posY>
-		<posZ>-7.0235</posZ>
+		<posZ>152.8935</posZ>
 		<scaleX>117.1666</scaleX>
 		<scaleY>105.3318</scaleY>
 		<scaleZ>111.0798</scaleZ>
 		<rotW>1.651873E-07</rotW>
-		<rotX>0.874413</rotX>
+		<rotX>0.8744129</rotX>
 		<rotY>1.011864E-07</rotY>
 		<rotZ>-0.4851826</rotZ>
 	</object>
@@ -35,13 +35,13 @@
 		<type>0</type>
 		<objectID>1</objectID>
 		<name>60719</name>
-		<posX>-77.628</posX>
+		<posX>50.7</posX>
 		<posY>-58.967</posY>
-		<posZ>-29.617</posZ>
+		<posZ>130.3</posZ>
 		<scaleX>40.21608</scaleX>
 		<scaleY>57.42638</scaleY>
 		<scaleZ>49.14267</scaleZ>
-		<rotW>-0.4826274</rotW>
+		<rotW>-0.4826273</rotW>
 		<rotX>-0.5886855</rotX>
 		<rotY>-0.6355971</rotY>
 		<rotZ>-0.1285957</rotZ>
@@ -50,39 +50,39 @@
 		<type>0</type>
 		<objectID>2</objectID>
 		<name>60719</name>
-		<posX>-61.807</posX>
+		<posX>66.521</posX>
 		<posY>-65.674</posY>
-		<posZ>-55.577</posZ>
+		<posZ>104.34</posZ>
 		<scaleX>50.95125</scaleX>
 		<scaleY>57.42638</scaleY>
 		<scaleZ>77.52333</scaleZ>
 		<rotW>0.273673</rotW>
-		<rotX>0.6371174</rotX>
-		<rotY>-0.386166</rotY>
+		<rotX>0.6371173</rotX>
+		<rotY>-0.3861659</rotY>
 		<rotZ>-0.608326</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>3</objectID>
 		<name>60711</name>
-		<posX>51.2</posX>
+		<posX>179.528</posX>
 		<posY>-62.4</posY>
-		<posZ>11.6</posZ>
+		<posZ>171.517</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
-		<rotW>-0.006543338</rotW>
-		<rotX>0.8809139</rotX>
-		<rotY>-0.4528682</rotY>
+		<rotW>-0.006543337</rotW>
+		<rotX>0.8809138</rotX>
+		<rotY>-0.4528681</rotY>
 		<rotZ>0.1373267</rotZ>
 	</object>
 	<object>
 		<type>0</type>
 		<objectID>5</objectID>
 		<name>60711</name>
-		<posX>25.4</posX>
+		<posX>153.728</posX>
 		<posY>-61</posY>
-		<posZ>-42.5</posZ>
+		<posZ>117.417</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
@@ -95,15 +95,15 @@
 		<type>0</type>
 		<objectID>6</objectID>
 		<name>60711</name>
-		<posX>-13.9</posX>
+		<posX>114.428</posX>
 		<posY>-38.3</posY>
-		<posZ>36.4</posZ>
+		<posZ>196.317</posZ>
 		<scaleX>93.73401</scaleX>
 		<scaleY>84.48326</scaleY>
 		<scaleZ>169.0282</scaleZ>
 		<rotW>-0.3307549</rotW>
-		<rotX>0.4307113</rotX>
-		<rotY>0.8085674</rotY>
+		<rotX>0.4307112</rotX>
+		<rotY>0.8085673</rotY>
 		<rotZ>-0.2265126</rotZ>
 	</object>
 </locationPrefab>


### PR DESCRIPTION
This adds ladder markers in the bandit forts. Now, activating (ie: clicking) on them will teleport you at the top or bottom of the ladder, like the ones in city interiors.

This also fixes the area and object positions of many prefabs, for proper road overlap detection